### PR TITLE
Add headers to request if in options

### DIFF
--- a/lib/url_fetcher.rb
+++ b/lib/url_fetcher.rb
@@ -84,6 +84,8 @@ class UrlFetcher
       Net::HTTP::Get.new(uri.request_uri)
     end
 
+    options[:headers].each { |k,v| request[k]=v } if options[:headers]
+
     response = http.request(request) do |resp|
       unless resp.is_a?(Net::HTTPSuccess) || resp.is_a?(Net::HTTPRedirection)
         resp.value # Raises an appropriate HTTP error

--- a/spec/url_fetcher_spec.rb
+++ b/spec/url_fetcher_spec.rb
@@ -125,4 +125,10 @@ describe UrlFetcher do
       UrlFetcher.new("http://example.com/test", :max_size => 1000)
     end.to raise_error(UrlFetcher::FileTooBig)
   end
+
+  it "should add headers to request" do
+    stub = stub_request(:get, "http://example.com/test").with(:headers => { 'User-Agent'=>"I'm a browser" })
+    url_fetcher = UrlFetcher.new("http://example.com/test", :headers => { "User-Agent" => "I'm a browser" })
+    expect(stub).to have_been_requested
+  end
 end


### PR DESCRIPTION
This is needed to overwrite User-Agent, Referer etc. to bypass hot-linking protection or user agent filtering.
